### PR TITLE
[web] added privacy, cookies, terms of service pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 
 <head>
+    <!-- Google analytics tracking-->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154698655-1"></script>
+    <script> window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag('js', new Date()); gtag('config', 'UA-154698655-1'); </script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -19,12 +23,8 @@
 
     <style>
         /*Fixes extra space on the right*/
-        body,
         html {
-            width: 100%;
-            height: 100%;
-            margin: 0px;
-            padding: 0px;
+            overflow-x: hidden !important;
         }
     </style>
 </head>

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -11,29 +11,40 @@ import LandingPage from './pages/LandingPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import NavigationBar from './components/common/Navbar.jsx';
 
+
+import Cookies from './components/landing/CookiesPolicy.jsx';
+import Privacy from './components/landing/PrivacyPolicy.jsx';
+import Terms from './components/landing/TermsOfService.jsx';
+
+
 class App extends React.Component {
 
-    render() {
-       return (
-         <div>
-             <AuthConsumer>
-                {({authenticated, login}) => (
-                  <>
-                    <NavigationBar />
-                    <Switch>
-                        <Route exact path={ROUTES.LANDING} component={LandingPage} />
-                        <Route path={ROUTES.LOGIN} component={() => (<LoginPage login={login} authenticated={authenticated} /> )} />
-                        <Route path={ROUTES.SIGN_UP} component={SignupPage} />
-                        
-                        {/* Protected Routes that need authentication */}
-                        <ProtectedRoute path={ROUTES.DASHBOARD} component={DashboardPage} authenticated={authenticated}/>
-                    </Switch>
-                  </>
-                )}
-            </AuthConsumer>
-         </div>
-       )
-    }
+  render() {
+    return (
+      <div>
+        <AuthConsumer>
+          {({ authenticated, login }) => (
+            <>
+              <NavigationBar />
+              <Switch>
+                <Route exact path={ROUTES.LANDING} component={LandingPage} />
+                <Route path={ROUTES.LOGIN} component={() => (<LoginPage login={login} authenticated={authenticated} />)} />
+                <Route path={ROUTES.SIGN_UP} component={SignupPage} />
+
+                <Route path={ROUTES.COOKIES} component={Cookies} />
+                <Route path={ROUTES.PRIVACY} component={Privacy} />
+                <Route path={ROUTES.TERM} component={Terms} />
+
+                {/* Protected Routes that need authentication */}
+                <ProtectedRoute path={ROUTES.DASHBOARD} component={DashboardPage} authenticated={authenticated} />
+              </Switch>
+
+            </>
+          )}
+        </AuthConsumer>
+      </div>
+    )
+  }
 }
 
 export default App;

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -33,7 +33,7 @@ class App extends React.Component {
 
                 <Route path={ROUTES.COOKIES} component={Cookies} />
                 <Route path={ROUTES.PRIVACY} component={Privacy} />
-                <Route path={ROUTES.TERM} component={Terms} />
+                <Route path={ROUTES.TERMS} component={Terms} />
 
                 {/* Protected Routes that need authentication */}
                 <ProtectedRoute path={ROUTES.DASHBOARD} component={DashboardPage} authenticated={authenticated} />

--- a/src/client/components/PoolStats.jsx
+++ b/src/client/components/PoolStats.jsx
@@ -3,62 +3,59 @@ import React, { Component } from 'react';
 import Style from '../styles/main.less';
 
 class PoolStatsComponent extends Component {
-
-
-
     render() {
         return (
-        <div>
-        <p className={Style.sectionHeader}>POOL STATS</p>
-            <div className={Style.graphs}>
-                <div className={Style.firstRow}>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>50.98 <span className={Style.cardSubText}>MH/sec</span></h3>
-                            <p className="card-text">Pool Hash Rate</p>
+            <div>
+                <p className={Style.sectionHeader}>POOL STATS</p>
+                <div className={Style.graphs}>
+                    <div className={Style.firstRow}>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>50.98 <span className={Style.cardSubText}>MH/sec</span></h3>
+                                <p className="card-text">Pool Hash Rate</p>
+                            </div>
+                        </div>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>22 <span className={Style.cardSubText}>Minutes</span></h3>
+                                <p className="card-text">Previous Block Found</p>
+                            </div>
+                        </div>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>9,477 <span className={Style.cardSubText}></span></h3>
+                                <p className="card-text">Miners Connected</p>
+                            </div>
                         </div>
                     </div>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>22 <span className={Style.cardSubText}>Minutes</span></h3>
-                            <p className="card-text">Previous Block Found</p>
+                    <div className={Style.secondRow}>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>333.94 <span className={Style.cardSubText}>MH/sec</span></h3>
+                                <p className="card-text">Network Hash Rate</p>
+                            </div>
                         </div>
-                    </div>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>9,477 <span className={Style.cardSubText}></span></h3>
-                            <p className="card-text">Miners Connected</p>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>2.4041 <span className={Style.cardSubText}>XMR</span></h3>
+                                <p className="card-text">Block Reward</p>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                <div className={Style.secondRow}>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>333.94 <span className={Style.cardSubText}>MH/sec</span></h3>
-                            <p className="card-text">Network Hash Rate</p>
-                        </div>
-                    </div>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>2.4041 <span className={Style.cardSubText}>XMR</span></h3>
-                            <p className="card-text">Block Reward</p>
-                        </div>
-                    </div>
-                    <div className={Style.card + "card"}>
-                        <img src="screenShot.png" className="card-img-top" alt="..." />
-                        <div className={Style.cardBody + "card-body"}>
-                            <h3>$70.60 <span className={Style.cardSubText}>USD</span></h3>
-                            <p className="card-text">XMR Value</p>
+                        <div className={Style.card + "card"}>
+                            <img src="screenShot.png" className="card-img-top" alt="..." />
+                            <div className={Style.cardBody + "card-body"}>
+                                <h3>$70.60 <span className={Style.cardSubText}>USD</span></h3>
+                                <p className="card-text">XMR Value</p>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
         )
     }
 }

--- a/src/client/components/landing/CookiesPolicy.jsx
+++ b/src/client/components/landing/CookiesPolicy.jsx
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import { Jumbotron } from 'react-bootstrap';
+
+import LandingFooter from './LandingFooter.jsx';
+
+class CookiesPolicy extends Component {
+    render() {
+        return (
+            <>
+                <Jumbotron className="w-75 mt-5 mx-auto">
+                    <h1>Cookie Policy</h1>
+                    <p>
+                        We use cookies to help improve your experience of https://myriade.io. This cookie policy is part of Myriade Inc.'s privacy policy, and covers the use of cookies between your device and our site. We also provide basic information on third-party services we may use, who may also use cookies as part of their service, though they are not covered by our policy.
+                    </p>
+                    <p>
+                        If you don’t wish to accept cookies from us, you should instruct your browser to refuse cookies from https://myriade.io, with the understanding that we may be unable to provide you with some of your desired content and services.
+                    </p>
+
+                    <h2>What is a cookie?</h2>
+                    <p>
+                        A cookie is a small piece of data that a website stores on your device when you visit, typically containing information about the website itself, a unique identifier that allows the site to recognise your web browser when you return, additional data that serves the purpose of the cookie, and the lifespan of the cookie itself.
+                    </p>
+                    <p>
+                        Cookies are used to enable certain features (eg. logging in), to track site usage (eg. analytics), to store your user settings (eg. timezone, notification preferences), and to personalise your content (eg. advertising, language).
+                    </p>
+                    <p>
+                        Cookies set by the website you are visiting are normally referred to as “first-party cookies”, and typically only track your activity on that particular site. Cookies set by other sites and companies (ie. third parties) are called “third-party cookies”, and can be used to track you on other websites that use the same third-party service.
+                    </p>
+
+                    <h2>Types of cookies and how we use them</h2>
+                    <h4>Essential cookies</h4>
+                    <p>
+                        Essential cookies are crucial to your experience of a website, enabling core features like user logins, account management, shopping carts and payment processing. We use essential cookies to enable certain functions on our website.
+                    </p>
+                    <h4>Performance cookies</h4>
+                    <p>
+                        Perfrmance cookies are used in the tracking of how you use a website during your visit, without collecting personal information about you. Typically, this information is anonymous and aggregated with information tracked across all site users, to help companies understand visitor usage patterns, identify and diagnose problems or errors their users may encounter, and make better strategic decisions in improving their audience’s overall website experience. These cookies may be set by the website you’re visiting (first-party) or by third-party services. We use performance cookies on our site.
+                    </p>
+                    <h4>Functionality cookies</h4>
+                    <p>
+                        Functionality cookies are used in collecting information about your device and any settings you may configure on the website you’re visiting (like language and time zone settings). With this information, websites can provide you with customised, enhanced or optimised content and services. These cookies may be set by the website you’re visiting (first-party) or by third-party service. We use functionality cookies for selected features on our site.
+                    </p>
+                    <h4>Targeting/advertising cookies</h4>
+                    <p>
+                        Targeting/advertising cookies are used in determining what promotional content is more relevant and appropriate to you and your interests. Websites may use them to deliver targeted advertising or to limit the number of times you see an advertisement. This helps companies improve the effectiveness of their campaigns and the quality of content presented to you. These cookies may be set by the website you’re visiting (first-party) or by third-party services. Targeting/advertising cookies set by third-parties may be used to track you on other websites that use the same third-party service. We use targeting/advertising cookies on our site.
+                    </p>
+                    <h4>Third-party cookies on our site</h4>
+                    <p>
+                        We may employ third-party companies and individuals on our websites—for example, analytics providers and content partners. We grant these third parties access to selected information to perform specific tasks on our behalf. They may also set third-party cookies in order to deliver the services they are providing. Third-party cookies can be used to track you on other websites that use the same third-party service. As we have no control over third-party cookies, they are not covered by Myriade Inc.'s cookie policy.
+                    </p>
+
+                    <h2>How you can control or opt out of cookies</h2>
+                    <p>
+                        If you do not wish to accept cookies from us, you can instruct your browser to refuse cookies from our website. Most browsers are configured to accept cookies by default, but you can update these settings to either refuse cookies altogether, or to notify you when a website is trying to set or update a cookie.
+                    </p>
+                    <p>
+                        If you browse websites from multiple devices, you may need to update your settings on each individual device.
+                    </p>
+                    <p>
+                        Although some cookies can be blocked with little impact on your experience of a website, blocking all cookies may mean you are unable to access certain features and content across the sites you visit.
+                    </p>
+                </Jumbotron>
+                <LandingFooter />
+            </>
+        );
+    }
+}
+
+export default CookiesPolicy;

--- a/src/client/components/landing/LandingBody.jsx
+++ b/src/client/components/landing/LandingBody.jsx
@@ -54,7 +54,7 @@ class LandingBody extends Component {
         <h3 className={Style.Title}>Frequently Asked Questions</h3>
         <Accordion>
           <Card>
-            <Accordion.Toggle as={Card.Header} eventKey="0">
+            <Accordion.Toggle as={Card.Header} eventKey="0" className={Style.faqToggle}>
               <Card.Title>What is Myriade?</Card.Title>
             </Accordion.Toggle>
             <Accordion.Collapse eventKey="0">

--- a/src/client/components/landing/LandingFooter.jsx
+++ b/src/client/components/landing/LandingFooter.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
-import { Row, Col, Container, Badge } from 'react-bootstrap';
+import { Row, Badge } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
+import * as ROUTES from '../../utils/routes.js';
 
 import Style from '../../styles/components/landing/footer.less';
 
@@ -19,9 +22,9 @@ class LandingFooter extends Component {
           </a>
         </Row>
         <Row className="justify-content-md-center m-2">
-          <a className="m-1" target="_blank">Privacy Policy</a>
-          <a className="m-1" target="_blank">Cookies Policy</a>
-          <a className="m-1" target="_blank">Terms of Service</a>
+          <Link className={'m-1 ' + Style.link} to={ROUTES.PRIVACY}>Privacy Policy</Link>
+          <Link className={'m-1 ' + Style.link} to={ROUTES.COOKIES}>Cookies Policy</Link>
+          <Link className={'m-1 ' + Style.link} to={ROUTES.TERMS}>Terms of Service</Link>
         </Row>
         <Row className="justify-content-md-center mt-2 pb-3">
           <p>Copyright © 2019, Myriade Inc.</p>

--- a/src/client/components/landing/PrivacyPolicy.jsx
+++ b/src/client/components/landing/PrivacyPolicy.jsx
@@ -1,0 +1,159 @@
+import React, { Component } from 'react';
+import { Jumbotron, Card } from 'react-bootstrap';
+
+import LandingFooter from './LandingFooter.jsx';
+
+class PrivacyPolicy extends Component {
+    render() {
+        return (
+            <>
+                <Jumbotron className="w-75 mt-5 mx-auto">
+                    <h1>Privacy Policy</h1>
+                    <p>
+                        Your privacy is important to us. It is Myriade Inc.'s policy to respect your privacy regarding any information we may collect from you across our website, https://myriade.io, and other sites we own and operate.
+                </p>
+
+                    <h2>1. Information we collect</h2>
+                    <h4>Log data</h4>
+                    <p>
+                        When you visit our website, our servers may automatically log the standard data provided by your web browser. It may include your computer’s Internet Protocol (IP) address, your browser type and version, the pages you visit, the time and date of your visit, the time spent on each page, and other details.
+                </p>
+                    <h4>Device Data</h4>
+                    <p>
+                        We may also collect data about the device you’re using to access our website. This data may include the device type, operating system, unique device identifiers, device settings, and geo-location data. What we collect can depend on the individual settings of your device and software. We recommend checking the policies of your device manufacturer or software provider to learn what information they make available to us.
+                </p>
+                    <h4>Personal information</h4>
+                    <p>We may ask for personal information, such as your:</p>
+                    <ul>
+                        <li>Email</li>
+                        <li>Phone/mobile number</li>
+                    </ul>
+
+                    <h2>2. Legal bases for processing</h2>
+                    <p>
+                        We will process your personal information lawfully, fairly and in a transparent manner. We collect and process information about you only where we have legal bases for doing so.
+                </p>
+                    <p>
+                        These legal bases depend on the services you use and how you use them, meaning we collect and use your information only where:
+                </p>
+                    <ul>
+                        <li>
+                            it’s necessary for the performance of a contract to which you are a party or to take steps at your request before entering into such a contract (for example, when we provide a service you request from us);
+                    </li>
+                        <li>
+                            it satisfies a legitimate interest (which is not overridden by your data protection interests), such as for research and development, to market and promote our services, and to protect our legal rights and interests;
+                    </li>
+                        <li>
+                            you give us consent to do so for a specific purpose (for example, you might consent to us sending you our newsletter); or
+                    </li>
+                        <li>
+                            we need to process your data to comply with a legal obligation.
+                    </li>
+                    </ul>
+                    <p>
+                        Where you consent to our use of information about you for a specific purpose, you have
+                        the right to change your mind at any time (but this will not affect any processing that
+                        has already taken place).
+                </p>
+                    <p>
+                        Where you consent to our use of information about you for a specific purpose, you have the right to change your mind at any time (but this will not affect any processing that has already taken place).
+                </p>
+
+                    <h2>3. Collection and use of information</h2>
+                    <p>
+                        We may collect, hold, use and disclose information for the following purposes and personal information will not be further processed in a manner that is incompatible with these purposes:
+                </p>
+                    <p>
+                        to enable you to customise or personalise your experience of our website;to enable you to access and use our website, associated applications and associated social media platforms;to contact and communicate with you;for internal record keeping and administrative purposes;for analytics, market research and business development, including to operate and improve our website, associated applications and associated social media platforms;to run competitions and/or offer additional benefits to you;for advertising and marketing, including to send you promotional information about our products and services and information about third parties that we consider may be of interest to you;to comply with our legal obligations and resolve any disputes that we may have; andto consider your employment application.
+                </p>
+
+                    <h2>4. Disclosure of personal information to third parties</h2>
+                    <p>
+                        We may disclose personal information to:
+                </p>
+                    <p>
+                        third party service providers for the purpose of enabling them to provide their services, including (without limitation) IT service providers, data storage, hosting and server providers, ad networks, analytics, error loggers, debt collectors, maintenance or problem-solving providers, marketing or advertising providers, professional advisors and payment systems operators;our employees, contractors and/or related entities;sponsors or promoters of any competition we run;credit reporting agencies, courts, tribunals and regulatory authorities, in the event you fail to pay for goods or services we have provided to you;courts, tribunals, regulatory authorities and law enforcement officers, as required by law, in connection with any actual or prospective legal proceedings, or in order to establish, exercise or defend our legal rights;third parties, including agents or sub-contractors, who assist us in providing information, products, services or direct marketing to you; andthird parties to collect and process data.
+                </p>
+
+                    <h2>5. International transfers of personal information</h2>
+                    <p>
+                        The personal information we collect is stored and processed in Canada and United States, or where we or our partners, affiliates and third-party providers maintain facilities. By providing us with your personal information, you consent to the disclosure to these overseas third parties.
+                </p>
+                    <p>
+                        We will ensure that any transfer of personal information from countries in the European Economic Area (EEA) to countries outside the EEA will be protected by appropriate safeguards, for example by using standard data protection clauses approved by the European Commission, or the use of binding corporate rules or other legally accepted means.
+                </p>
+                    <p>
+                        Where we transfer personal information from a non-EEA country to another country, you acknowledge that third parties in other jurisdictions may not be subject to similar data protection laws to the ones in our jurisdiction. There are risks if any such third party engages in any act or practice that would contravene the data privacy laws in our jurisdiction and this might mean that you will not be able to seek redress under our jurisdiction’s privacy laws.
+                </p>
+
+                    <h2>6. Your rights and controlling your personal information</h2>
+                    <p>
+                        Choice and consent: By providing personal information to us, you consent to us collecting, holding, using and disclosing your personal information in accordance with this privacy policy. If you are under 16 years of age, you must have, and warrant to the extent permitted by law to us, that you have your parent or legal guardian’s permission to access and use the website and they (your parents or guardian) have consented to you providing us with your personal information. You do not have to provide personal information to us, however, if you do not, it may affect your use of this website or the products and/or services offered on or through it.
+                </p>
+                    <p>
+                        Information from third parties: If we receive personal information about you from a third party, we will protect it as set out in this privacy policy. If you are a third party providing personal information about somebody else, you represent and warrant that you have such person’s consent to provide the personal information to us.
+                </p>
+                    <p>
+                        Restrict: You may choose to restrict the collection or use of your personal information. If you have previously agreed to us using your personal information for direct marketing purposes, you may change your mind at any time by contacting us using the details below. If you ask us to restrict or limit how we process your personal information, we will let you know how the restriction affects your use of our website or products and services.
+                </p>
+                    <p>
+                        Access and data portability: You may request details of the personal information that we hold about you. You may request a copy of the personal information we hold about you. Where possible, we will provide this information in CSV format or other easily readable machine format. You may request that we erase the personal information we hold about you at any time. You may also request that we transfer this personal information to another third party.
+                </p>
+                    <p>
+                        Correction: If you believe that any information we hold about you is inaccurate, out of date, incomplete, irrelevant or misleading, please contact us using the details below. We will take reasonable steps to correct any information found to be inaccurate, incomplete, misleading or out of date.
+                </p>
+                    <p>
+                        Notification of data breaches: We will comply laws applicable to us in respect of any data breach.
+                </p>
+                    <p>
+                        Complaints: If you believe that we have breached a relevant data protection law and wish to make a complaint, please contact us using the details below and provide us with full details of the alleged breach. We will promptly investigate your complaint and respond to you, in writing, setting out the outcome of our investigation and the steps we will take to deal with your complaint. You also have the right to contact a regulatory body or data protection authority in relation to your complaint.
+                </p>
+                    <p>
+                        Unsubscribe: To unsubscribe from our e-mail database or opt-out of communications (including marketing communications), please contact us using the details below or opt-out using the opt-out facilities provided in the communication.
+                </p>
+
+                    <h2>7. Cookies</h2>
+                    <p>
+                        We use “cookies” to collect information about you and your activity across our site. A cookie is a small piece of data that our website stores on your computer, and accesses each time you visit, so we can understand how you use our site. This helps us serve you content based on preferences you have specified. Please refer to our Cookie Policy for more information.
+                </p>
+
+                    <h2>8. Business transfers</h2>
+                    <p>
+                        If we or our assets are acquired, or in the unlikely event that we go out of business or enter bankruptcy, we would include data among the assets transferred to any parties who acquire us. You acknowledge that such transfers may occur, and that any parties who acquire us may continue to use your personal information according to this policy.
+                </p>
+
+                    <h2>9. Limits of our policy</h2>
+                    <p>
+                        Our website may link to external sites that are not operated by us. Please be aware that we have no control over the content and policies of those sites, and cannot accept responsibility or liability for their respective privacy practices.
+                </p>
+
+                    <h2>10. Changes to this policy</h2>
+                    <p>
+                        At our discretion, we may change our privacy policy to reflect current acceptable practices. We will take reasonable steps to let users know about changes via our website. Your continued use of this site after any changes to this policy will be regarded as acceptance of our practices around privacy and personal information.
+                </p>
+                    <p>
+                        If we make a significant change to this privacy policy, for example changing a lawful basis on which we process your personal information, we will ask you to re-consent to the amended privacy policy.
+                </p>
+
+                    <Card>
+                        <Card.Body>
+                            <h4>Myriade Inc. Data Controller</h4>
+                            <p>Rifat Hanano</p>
+                            <p>data@myriade.io</p>
+
+                            <h4>Myriade Inc. Data Protection Officer</h4>
+                            <p>Rifat Hanano</p>
+                            <p>data@myriade.io</p>
+                        </Card.Body>
+                    </Card>
+
+                    <p>This policy is effective as of 30 November 2019.</p>
+
+                </Jumbotron>
+                <LandingFooter />
+            </>
+        );
+    }
+}
+
+export default PrivacyPolicy;

--- a/src/client/components/landing/TermsOfService.jsx
+++ b/src/client/components/landing/TermsOfService.jsx
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import { Jumbotron } from 'react-bootstrap';
+
+import LandingFooter from './LandingFooter.jsx';
+
+class TermsOfService extends Component {
+    render() {
+        return (
+            <>
+                <Jumbotron className="w-75 mt-5 mx-auto">
+                    <h1>Myriade Inc. Terms of Service</h1>
+
+                    <h2>1. Terms</h2>
+                    <p>
+                        By accessing the website at https://myriade.io, you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
+                </p>
+
+                    <h2>2. Use Licence</h2>
+                    <p>
+                        Permission is granted to temporarily download one copy of the materials (information or software) on Myriade Inc.'s website for personal, non-commercial transitory viewing only. This is the grant of a licence, not a transfer of title, and under this licence you may not:
+                </p>
+                    <ul>
+                        <li>modify or copy the materials;</li>
+                        <li>use the materials for any commercial purpose, or for any public display (commercial or non-commercial);</li>
+                        <li>attempt to decompile or reverse engineer any software contained on Myriade Inc.'s website;</li>
+                        <li>remove any copyright or other proprietary notations from the materials; or</li>
+                        <li>transfer the materials to another person or "mirror" the materials on any other server.</li>
+                    </ul>
+                    <p>
+                        This licence shall automatically terminate if you violate any of these restrictions and may be terminated by Myriade Inc. at any time. Upon terminating your viewing of these materials or upon the termination of this licence, you must destroy any downloaded materials in your possession whether in electronic or printed format.
+                </p>
+
+                    <h2>3. Disclaimer</h2>
+                    <p>
+                        The materials on Myriade Inc.'s website are provided on an 'as is' basis. Myriade Inc. makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
+                </p>
+                    <p>
+                        Further, Myriade Inc. does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its website or otherwise relating to such materials or on any sites linked to this site.
+                </p>
+
+                    <h2>4. Limitations</h2>
+                    <p>
+                        In no event shall Myriade Inc. or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on Myriade Inc.'s website, even if Myriade Inc. or a Myriade Inc. authorised representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.
+                </p>
+
+                    <h2>5. Accuracy of materials</h2>
+                    <p>
+                        The materials appearing on Myriade Inc.'s website could include technical, typographical, or photographic errors. Myriade Inc. does not warrant that any of the materials on its website are accurate, complete or current. Myriade Inc. may make changes to the materials contained on its website at any time without notice. However Myriade Inc. does not make any commitment to update the materials.
+                </p>
+
+                    <h2>6. Links</h2>
+                    <p>
+                        Myriade Inc. has not reviewed all of the sites linked to its website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by Myriade Inc. of the site. Use of any such linked website is at the user's own risk.
+                </p>
+
+                    <h2>7. Modifications</h2>
+                    <p>
+                        Myriade Inc. may revise these terms of service for its website at any time without notice. By using this website you are agreeing to be bound by the then current version of these terms of service.
+                </p>
+
+                    <h2>8. Governing Law</h2>
+                    <p>
+                        These terms and conditions are governed by and construed in accordance with the laws of Montreal, Qc, Canada and you irrevocably submit to the exclusive jurisdiction of the courts in that State or location.
+                </p>
+                </Jumbotron>
+                <LandingFooter />
+            </>
+        );
+    }
+}
+
+export default TermsOfService;

--- a/src/client/styles/components/landing/footer.less
+++ b/src/client/styles/components/landing/footer.less
@@ -10,4 +10,5 @@
 }
 .link:hover{
     color: #F07C00;
+    text-decoration: none;
 }

--- a/src/client/styles/components/landing/main.less
+++ b/src/client/styles/components/landing/main.less
@@ -64,3 +64,7 @@ hr {
     width: 100%;
     height: 500px; 
 }
+
+.faqToggle{
+    cursor: pointer;
+}

--- a/src/client/utils/routes.js
+++ b/src/client/utils/routes.js
@@ -3,3 +3,6 @@ export const LOGIN = '/login';
 export const DASHBOARD = '/dashboard';
 export const LANDING = '/';
 export const GAMEROOM = '/gameroom';
+export const COOKIES = '/cookies';
+export const PRIVACY = '/privacy';
+export const TERMS = '/terms';


### PR DESCRIPTION
Ticket | Title
---|---
#18 | [web] Adding a Privacy Policy Page
#19 | [web] Adding a Cookies Policy Page
#20 | [web] Adding a Terms of Service Page
#31 | [web] Paul's Recommendations

## Description
- Added the privacy, terms of service, and cookies pages and linked them in the footer
- Made some slight UI changes and fixes, as outlined in #31 

## Screenshots
![image](https://user-images.githubusercontent.com/22998430/71550737-33958100-29a5-11ea-975f-4f390635c9dd.png)
![image](https://user-images.githubusercontent.com/22998430/71550738-3e501600-29a5-11ea-8000-4b13b559481d.png)
![image](https://user-images.githubusercontent.com/22998430/71550742-4740e780-29a5-11ea-86ff-30f078f97cd3.png)
