### PR TITLE
[web] Stay signed in for 1 hour

### DIFF
--- a/src/client/layers/AuthLayer.jsx
+++ b/src/client/layers/AuthLayer.jsx
@@ -25,13 +25,13 @@ class AuthLayer extends Component {
     }
   }
 
-  // componentDidMount() {
-  //   if (localStorage.hasOwnProperty("access_token")) {
-  //     let decodedToken = decode(localStorage.getItem("access_token"));
-  //     let expired = Date.now() > decodedToken.exp * 1000;
-  //     this.setState({ authenticated: !expired });
-  //   }
-  // }
+  componentDidMount() {
+    if (localStorage.hasOwnProperty("access_token")) {
+      let decodedToken = decode(localStorage.getItem("access_token"));
+      let expired = Date.now() > decodedToken.exp;
+      this.setState({ authenticated: !expired });
+    }
+  }
 
   login(email, password) {
     console.log("here " + config.identity_service_url);

--- a/src/client/layers/AuthLayer.jsx
+++ b/src/client/layers/AuthLayer.jsx
@@ -5,7 +5,6 @@ import decode from 'jwt-decode';
 import axios from 'axios';
 import * as ROUTES from '../utils/routes.js'
 
-
 import config from '../utils/config.js';
 
 const authContext = createContext();
@@ -24,8 +23,15 @@ class AuthLayer extends Component {
       login: this.login,
       jwtToken: null
     }
-
   }
+
+  // componentDidMount() {
+  //   if (localStorage.hasOwnProperty("access_token")) {
+  //     let decodedToken = decode(localStorage.getItem("access_token"));
+  //     let expired = Date.now() > decodedToken.exp * 1000;
+  //     this.setState({ authenticated: !expired });
+  //   }
+  // }
 
   login(email, password) {
     console.log("here " + config.identity_service_url);
@@ -50,7 +56,7 @@ class AuthLayer extends Component {
 
   updateAuth(accessToken) {
     localStorage.setItem('access_token', accessToken);
-    const decodedToken = decode(accessToken);
+    let decodedToken = decode(accessToken);
     this.setState({
       miner: {
         id: decodedToken.sub,

--- a/src/client/utils/config.js
+++ b/src/client/utils/config.js
@@ -1,6 +1,6 @@
 
 const config = {
-  identity_service_url: 'https://staging.myriade.io/id',
+  identity_service_url: 'http://127.0.0.1:8180',
   miner_metrics_url: 'https://staging.myriade.io/metrics',
   raffles_url: 'https://onyx-alpha.herokuapp.com'
 }


### PR DESCRIPTION
Ticket | Title
---|---
fixes #23 | [web] Stay signed in for an hour

## Description

Allows users to stay signed in for an hour.

## Implementation / Approach

In `diamond/src/services/token.service.js`, the service generates the UNIX time of 1 hour ahead of the present time, * 1000. (bug outlined in).

In `web/src/client/layers/AuthLayer.jsx`, the component checks if the current time is ahead of the JWT token's expiry value.