### PR TITLE
[web] Made get started button point

### DIFF
--- a/src/client/components/landing/LandingBody.jsx
+++ b/src/client/components/landing/LandingBody.jsx
@@ -227,9 +227,11 @@ const Compare = (props) => {
                             />
                             <div> H/s</div>
                         </div>
-                        <DarkGradientButton pill>
-                            Get Started
-                        </DarkGradientButton>
+                        <WhiteLink to={ROUTES.SIGN_UP}>
+                            <DarkGradientButton pill>
+                                Get Started
+                            </DarkGradientButton>
+                        </WhiteLink>
                     </Col>
                     <Col md={6}>
                         <div


### PR DESCRIPTION
## Description
The gradient get started button was not pointing anywhere. It now points to the login page.

## Checklist

- [ ] Appropriate Unit test coverage
- [ ] Manual top-hatting has been performed
- [ ] This PR is linted, tested and follows the best practices of the organization