### PR TITLE
Purchase button disabled for expired raffles - ALPHA-15

### DIFF
--- a/src/client/components/dashboard/games/Raffle.jsx
+++ b/src/client/components/dashboard/games/Raffle.jsx
@@ -44,54 +44,64 @@ class Raffle extends Component {
             raffle: null,
             error: null,
             USD: 121.36,
-            success: null
+            success: null,
         }
     }
 
     displaySuccess() {
         return (
-            <Alert theme="success" dismissible={() => this.setState({ success: null })}>
+            <Alert
+                theme="success"
+                dismissible={() => this.setState({ success: null })}
+            >
                 {this.state.success}
             </Alert>
         )
     }
 
     componentDidMount() {
-        axios.get(`${config.miner_metrics_url}/v1/eventContent/active`)
-        .then((response) => {
-            this.setState({ raffle: response.data })
-        })
-        .catch((error) => {
-            console.error('There was an error!', error)
-            return this.setState({
-                error:
-                    'Unable to fetch your data, please check your connection, your login and try again later',
+        axios
+            .get(`${config.miner_metrics_url}/v1/eventContent/active`)
+            .then((response) => {
+                this.setState({ raffle: response.data })
             })
-        })
-
-        axios.get(`${config.miner_metrics_url}/v1/credits/allEvents`, {
-            headers: {
-                Authorization: `Bearer ${localStorage.getItem(
-                    'access_token'
-                )}`,
-            },
-        })
-        .then((response) => {
-            this.setState({ purchasedTickets: response.data.entries })
-        })
-        .catch((error) => {
-            console.error('There was an error!', error)
-            return this.setState({
-                error:'Unable to fetch your data, please check your connection, your login and try again later',
+            .catch((error) => {
+                console.error('There was an error!', error)
+                return this.setState({
+                    error:
+                        'Unable to fetch your data, please check your connection, your login and try again later',
+                })
             })
-        })
 
-        axios.get(`https://min-api.cryptocompare.com/data/price?fsym=XMR&tsyms=USD`).then((response) => {
-            this.setState(response.data)
-        })
-        .catch((error) => {
-            console.error('There was an error!', error)
-        })
+        axios
+            .get(`${config.miner_metrics_url}/v1/credits/allEvents`, {
+                headers: {
+                    Authorization: `Bearer ${localStorage.getItem(
+                        'access_token'
+                    )}`,
+                },
+            })
+            .then((response) => {
+                this.setState({ purchasedTickets: response.data.entries })
+            })
+            .catch((error) => {
+                console.error('There was an error!', error)
+                return this.setState({
+                    error:
+                        'Unable to fetch your data, please check your connection, your login and try again later',
+                })
+            })
+
+        axios
+            .get(
+                `https://min-api.cryptocompare.com/data/price?fsym=XMR&tsyms=USD`
+            )
+            .then((response) => {
+                this.setState(response.data)
+            })
+            .catch((error) => {
+                console.error('There was an error!', error)
+            })
         // TODO: Query description field once supported on Onyx
         // gqlRaffles
         //     .query({
@@ -141,38 +151,41 @@ class Raffle extends Component {
         this.setState({ modalShow: false })
         let component = this
         // Buy a raffle ticket if purchase = true
-        if(purchase){
+        if (purchase) {
             const options = {
                 method: 'post',
                 url: `${config.miner_metrics_url}/v1/credits/buy`,
                 data: {
                     amount: this.state.tickets,
-                    contentId: this.state.raffle[this.state.drawOption].id
+                    contentId: this.state.raffle[this.state.drawOption].id,
                 },
                 headers: {
                     Authorization: `Bearer ${localStorage.getItem(
                         'access_token'
                     )}`,
                 },
-              };
+            }
 
             axios(options)
-              .then(function (response) {
-                if(response.status == 200){
-                    component.setState({success: "Ticket purchase successful!"})
-                } else {
-                    return component.setState({
-                        error:'Unable to purchase the ticket, please check your connection, and try again later',
-                    })
-                }
-              })
-              .catch(function (error) {
-                console.error('There was an error!', error)
-                return this.setState({
-                    error:
-                        'Unable to purchase the ticket, please check your connection, and try again later',
+                .then(function (response) {
+                    if (response.status == 200) {
+                        component.setState({
+                            success: 'Ticket purchase successful!',
+                        })
+                    } else {
+                        return component.setState({
+                            error:
+                                'Unable to purchase the ticket, please check your connection, and try again later',
+                        })
+                    }
                 })
-              })
+                .catch(function (error) {
+                    console.error('There was an error!', error)
+                    return this.setState({
+                        error:
+                            'Unable to purchase the ticket, please check your connection, and try again later',
+                    })
+                })
         }
     }
 
@@ -253,7 +266,8 @@ class Raffle extends Component {
                                 <Col>
                                     <Card.Title>
                                         {formatMoney(
-                                            value.public.prizeAmount * this.state.USD
+                                            value.public.prizeAmount *
+                                                this.state.USD
                                         )}
                                         USD
                                     </Card.Title>
@@ -263,16 +277,19 @@ class Raffle extends Component {
                                 </Col>
                             </Row>
                             <Card.Subtitle className="mb-2 text-muted">
-                                <i className="fab fa-monero" /> {value.public.prizeAmount}XMR
+                                <i className="fab fa-monero" />{' '}
+                                {value.public.prizeAmount}XMR
                             </Card.Subtitle>
-                            <Card.Text className={Style.orange + " mb-0"}>
-                            {value.public.title}
+                            <Card.Text className={Style.orange + ' mb-0'}>
+                                {value.public.title}
                             </Card.Text>
                             <Card.Text>
                                 Ticket price: {value.public.entryPrice}MC
                             </Card.Text>
                             {value.public.description && (
-                                <Card.Text>{value.public.description}</Card.Text>
+                                <Card.Text>
+                                    {value.public.description}
+                                </Card.Text>
                             )}
                         </Card.Body>
                         <Card.Footer>
@@ -301,7 +318,7 @@ class Raffle extends Component {
                 p.getUTCMinutes() +
                 ':' +
                 p.getUTCSeconds()
-            let expiryDate = moment(value.eventTime).format('lll') 
+            let expiryDate = moment(value.eventTime).format('lll')
             let status = value.status
 
             return (
@@ -387,7 +404,7 @@ class Raffle extends Component {
                                                 this.state.raffle[
                                                     this.state.drawOption
                                                 ].public.prizeAmount *
-                                                this.state.USD
+                                                    this.state.USD
                                             )}
                                             USD
                                             <small className="text-muted">
@@ -451,7 +468,8 @@ class Raffle extends Component {
                                             </small>
                                             {this.state.raffle[
                                                 this.state.drawOption
-                                            ].public.entryPrice * this.state.tickets}
+                                            ].public.entryPrice *
+                                                this.state.tickets}
                                             MC
                                         </h4>
                                     </div>
@@ -469,7 +487,12 @@ class Raffle extends Component {
                                 <Button
                                     variant="primary"
                                     onClick={() => {
-                                        this.handleClose(true)}
+                                        this.handleClose(true)
+                                    }}
+                                    disabled={
+                                        this.state.countdownString[
+                                            this.state.drawOption
+                                        ] === 'EXPIRED'
                                     }
                                 >
                                     Confirm Purchase


### PR DESCRIPTION
Ticket | Title
---|---
ALPHA-17| Disable buy option for raffles that are expired

## Description

The purchase button was interactable despite the raffle being expired.

## Implementation / Approach

Check the raffle status and disable the buy button if it's expired.

## Checklist

- [ ] Appropriate Unit test coverage
- [ ] Manual top-hatting has been performed
- [ ] This PR is linted, tested and follows the best practices of the organization