### PR TITLE
Fixed email verification bug - ALPHA-19

### DIFF
--- a/src/client/pages/SignupPage.jsx
+++ b/src/client/pages/SignupPage.jsx
@@ -70,7 +70,7 @@ class SignupPage extends Component {
         e.preventDefault()
         const email = e.target.elements.email.value
         axios
-            .post(`${config.identity_service_url}/v1/email/create`, {
+            .post(`${config.identity_service_url}/v1/email/`, {
                 email,
             })
             .then(() => {


### PR DESCRIPTION
Ticket | Title
---|---
#ALPHA-19 | Create account "Failed to send email confirmation, please double check your email address" error 

## Description

404 error when entering an email on the signup page.

## Implementation / Approach

The frontend was calling the wrong endpoint (v1/email/create rather than v1/email/).

## Checklist

- [ ] Appropriate Unit test coverage
- [ ] Manual top-hatting has been performed
- [ ] This PR is linted, tested and follows the best practices of the organization